### PR TITLE
Better resolution support

### DIFF
--- a/examples/commands.rs
+++ b/examples/commands.rs
@@ -13,7 +13,7 @@ use f3::hal::delay::Delay;
 use f3::hal::i2c::I2c;
 use f3::hal::stm32f30x;
 use ssd1306::prelude::Write;
-use ssd1306::{Ssd1306, ADDRESS};
+use ssd1306::{Ssd1306, ADDRESS, Resolution};
 use ssd1306::cmd::{Command, Page};
 
 fn draw_border<I2C>(i2c: &mut I2C) -> Result<(), I2C::Error>
@@ -81,7 +81,7 @@ fn main() {
         .into_push_pull_output(&mut gpiob.moder, &mut gpiob.otyper);
 
     let mut delay = Delay::new(cp.SYST, clocks);
-    let mut ssd1306 = Ssd1306::new(i2c1, ADDRESS, 128, 32);
+    let mut ssd1306 = Ssd1306::new(i2c1, ADDRESS, Resolution::R128x32, true);
 
     ssd1306.reset(&mut rst, &mut delay);
     ssd1306.init().unwrap();

--- a/examples/driver.rs
+++ b/examples/driver.rs
@@ -12,7 +12,7 @@ use f3::hal::prelude::*;
 use f3::hal::delay::Delay;
 use f3::hal::i2c::I2c;
 use f3::hal::stm32f30x;
-use ssd1306::{Ssd1306, ADDRESS};
+use ssd1306::{Ssd1306, ADDRESS, Resolution};
 
 fn main() {
     let cp = cortex_m::Peripherals::take().unwrap();
@@ -31,7 +31,7 @@ fn main() {
         .into_push_pull_output(&mut gpiob.moder, &mut gpiob.otyper);
 
     let mut delay = Delay::new(cp.SYST, clocks);
-    let mut ssd1306 = Ssd1306::new(i2c1, ADDRESS, 128, 32);
+    let mut ssd1306 = Ssd1306::new(i2c1, ADDRESS, Resolution::R128x32, true);
 
     ssd1306.reset(&mut rst, &mut delay);
     ssd1306.init().unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,7 @@ use prelude::Write;
 
 /// Default i2c address
 pub const ADDRESS: u8 = 0x3C;
-const BUF_SIZE: usize = 128 * 32 / 8;
+const BUF_SIZE: usize = 128 * 64 / 8;
 
 /// Ssd1306
 pub struct Ssd1306<I2C> {


### PR DESCRIPTION
@therealprof re: #4

Seems like 128x32, 128x64, and 96x16 are the common resolutions out there. This adds support for those, as well as support for deciding whether or not to use the internal charge pump.